### PR TITLE
Add Volto auth cookie in the list of cookies not to be removed

### DIFF
--- a/varnish.vcl
+++ b/varnish.vcl
@@ -104,7 +104,8 @@ sub vcl_recv {
 
     set req.http.UrlNoQs = regsub(req.url, "\?.*$", "");
     # Do not cache authenticated requests
-    if (req.http.Cookie && req.http.Cookie ~ "__ac(|__\w+|_(name|password|persistent))=")
+    if (req.http.Cookie && req.http.Cookie ~ "(__ac(|__\w+|_(name|password|persistent))=|auth_token=)")
+
     {
        if (req.http.UrlNoQs ~ "\.(js|css)$") {
             unset req.http.cookie;


### PR DESCRIPTION
After an external login process, we are setting the `auth_token` cookie in the Plone backend (as opposed to the standard login on Volto where the cookie is set by the frontend), so when using this Varnish image in front of the Plone backend, deletes the cookie and the front-end can't get its authentication.

Volto edition environment works nevertheless this modification, because although the `auth_token` cookie is removed all Volto requests to the backend have the `Authorization` HTTP-Header, which is not stripped by Varnish.